### PR TITLE
added createDepositAddress

### DIFF
--- a/js/sparkswap.js
+++ b/js/sparkswap.js
@@ -24,6 +24,8 @@ module.exports = class sparkswap extends Exchange {
             'requiredCredentials': {
                 'uid': true,
                 'password': true,
+                'apiKey': false,
+                'secret': false,
             },
             'has': {
                 // We do not support CORS w/ headers
@@ -117,8 +119,9 @@ module.exports = class sparkswap extends Exchange {
         throw new ExchangeError ('Not Implemented');
     }
 
-    async createDepositAddress () {
-        throw new ExchangeError ('Not Implemented');
+    async createDepositAddress (symbol, params = {}) {
+        let res = await this.privatePostV1WalletAddress ({ symbol });
+        return res.address;
     }
 
     async createOrder (symbol, type, side, amount, price = undefined, params = {}) {


### PR DESCRIPTION
This PR adds `createDepositAddress` functionality to the sparkswap ccxt exchange. This PR also disables checks for `apiKey` and `secret` because we do not use these properties w/ the daemon