### PR TITLE
Add create order command, add options and errors

### DIFF
--- a/js/sparkswap.js
+++ b/js/sparkswap.js
@@ -95,7 +95,6 @@ module.exports = class sparkswap extends Exchange {
                 },
             },
             'exceptions': {},
-            'markets': {},
             'options': {
                 'defaultTimeInForce': 'GTC', // 'GTC' = Good To Cancel (default), 'IOC' = Immediate Or Cancel
             },

--- a/js/sparkswap.js
+++ b/js/sparkswap.js
@@ -4,16 +4,6 @@
 
 const Exchange = require ('./base/Exchange');
 const { ExchangeError, BadRequest } = require ('./base/errors');
-const CONSTANTS = {
-    'orderTypes': {
-        'buy': 'buy',
-        'sell': 'sell',
-    },
-    'sides': {
-        'bid': 'BID',
-        'ask': 'ASK',
-    },
-}
 
 // ----------------------------------------------------------------------------
 
@@ -146,20 +136,32 @@ module.exports = class sparkswap extends Exchange {
     }
 
     async createOrder (symbol, type, side, amount, price = undefined, params = {}) {
+        const CONSTANTS = {
+            'ORDER_TYPES': {
+                'LIMIT': 'limit',
+                'MARKET': 'market',
+            },
+            'SIDES': {
+                'BUY': 'buy',
+                'SELL': 'sell',
+                'BID': 'BID',
+                'ASK': 'ASK',
+            },
+        };
         await this.loadMarkets ();
         let orderType = undefined;
-        if (side === CONSTANTS.orderTypes.buy) {
-            orderType = CONSTANTS.sides.bid;
-        } else if (side === CONSTANTS.orderTypes.sell) {
-            orderType = CONSTANTS.sides.ask;
+        if (side === CONSTANTS.SIDES.BUY) {
+            orderType = CONSTANTS.SIDES.BID;
+        } else if (side === CONSTANTS.SIDES.SELL) {
+            orderType = CONSTANTS.SIDES.ASK;
         }
         const order = {
             'market': this.marketId (symbol),
             'amount': amount.toString (),
             'side': orderType,
         };
-        const marketOrder = (type === 'market');
-        const limitOrder = (type === 'limit');
+        const marketOrder = (type === CONSTANTS.ORDER_TYPES.MARKET);
+        const limitOrder = (type === CONSTANTS.ORDER_TYPES.LIMIT);
         if (limitOrder) {
             if (price === undefined) {
                 throw new BadRequest (this.id + ' createOrder method requires a price argument for a ' + type + ' order');

--- a/js/sparkswap.js
+++ b/js/sparkswap.js
@@ -133,19 +133,18 @@ module.exports = class sparkswap extends Exchange {
         } else if (side === 'sell') {
             orderType = 'ASK';
         }
-        let order = {
+        const order = {
             'market': this.marketId (symbol),
             'amount': amount.toString (),
             'side': orderType,
         };
-        let priceIsDefined = (price !== undefined);
-        let marketOrder = (type === 'market');
-        let limitOrder = (type === 'limit');
+        const marketOrder = (type === 'market');
+        const limitOrder = (type === 'limit');
         let timeInForceIsRequired = false;
-        let shouldIncludePrice = limitOrder || (!marketOrder && priceIsDefined);
-        if (shouldIncludePrice) {
-            if (price === undefined)
-                throw new InvalidOrder (this.id + ' createOrder method requires a price argument for a ' + type + ' order');
+        if (limitOrder) {
+            if (price === undefined) {
+                throw new InvalidOrder (this.id + ' createOrder method requires a price argument for a ' + type + ' order');  
+            }
             order['limit_price'] = price.toString ();
             timeInForceIsRequired = true;
         }
@@ -155,7 +154,7 @@ module.exports = class sparkswap extends Exchange {
         if (timeInForceIsRequired) {
             order['time_in_force'] = this.options['defaultTimeInForce']; // 'GTC' = Good To Cancel (default), 'IOC' = Immediate Or Cancel
         }
-        let response = await this.privatePostV1Orders (this.extend (order, params));
+        let response = await this.privatePostV1Orders (order, params);
         return {
             'info': response,
             'id': response['block_order_id'],


### PR DESCRIPTION
https://github.com/sparkswap/broker/pull/257

Add a `createOrder` method to the ccxt base class for sparkswap