### PR TITLE
FEATURE - fetchTicker

### DIFF
--- a/js/sparkswap.js
+++ b/js/sparkswap.js
@@ -282,8 +282,9 @@ module.exports = class sparkswap extends Exchange {
         throw new ExchangeError ('Not Implemented');
     }
 
-    async fetchTicker () {
-        throw new ExchangeError ('Not Implemented');
+    async fetchTicker (symbol, params = {}) {
+        await this.loadMarkets ();
+        return this.privateGetV1MarketStats ({ 'market': this.marketId (symbol) });
     }
 
     async fetchTrades () {

--- a/js/sparkswap.js
+++ b/js/sparkswap.js
@@ -276,9 +276,9 @@ module.exports = class sparkswap extends Exchange {
 
     async fetchOrderBook (symbol, params = {}) {
         await this.loadMarkets ();
-        // This call will return the correct information that CCXT will expect, however
-        // we need to modify the payload to convert nanosecond timestamps to miliseconds
-        //
+        // The call to v1/orderbook will return the correct information that CCXT will
+        // expect, however we need to modify the payload to convert nanosecond timestamps
+        // to miliseconds
         const res = await this.privateGetV1Orderbook ({ 'market': this.marketId (symbol) });
         const millisecondTimestamp = this.nanoToMillisecondTimestamp (res.timestamp);
         const millisecondDatetime = this.nanoToMillisecondDatetime (res.datetime);
@@ -296,9 +296,9 @@ module.exports = class sparkswap extends Exchange {
 
     async fetchTicker (symbol, params = {}) {
         await this.loadMarkets ();
-        // This call will return the correct information that CCXT will expect, however
-        // we need to modify the payload to convert nanosecond timestamps to miliseconds
-        //
+        // The call to v1/market_stats will return the correct information that CCXT will
+        // expect, however we need to modify the payload to convert nanosecond timestamps
+        // to miliseconds
         const res = await this.privateGetV1MarketStats ({ 'market': this.marketId (symbol) });
         const millisecondTimestamp = this.nanoToMillisecondTimestamp (res.timestamp);
         const millisecondDatetime = this.nanoToMillisecondDatetime (res.datetime);


### PR DESCRIPTION
This PR adds functionality for the `fetchTicker` function.

Changes:
1. adds `nanoToMillisecondTimestamp` helper function
2. adds `nanoToMillisecondDatetime` helper function
3. modifies `fetchOrderbook` to use helper functions
4. adds `fetchTicker` functionality

Example:
<img width="659" alt="screen shot 2018-10-03 at 10 10 31 pm" src="https://user-images.githubusercontent.com/5478311/46454048-4b0d9c00-c759-11e8-9f96-0ab07dfe636c.png">
